### PR TITLE
cio: Made ReadableProxy load external data lazily

### DIFF
--- a/sdk_service/src/ivcap_sdk_service/cio/io_adapter.py
+++ b/sdk_service/src/ivcap_sdk_service/cio/io_adapter.py
@@ -70,7 +70,7 @@ class IOReadable(_IOBase):
 
     @property
     @abstractmethod
-    def path(self) -> str:
+    def as_local_file(self) -> str:
         pass
 
 class IOWritable(_IOBase):

--- a/sdk_service/src/ivcap_sdk_service/cio/local_io_adapter.py
+++ b/sdk_service/src/ivcap_sdk_service/cio/local_io_adapter.py
@@ -138,8 +138,8 @@ class LocalIOAdapter(IOAdapter):
             name = p.replace('/', '__')
             use_temp_file = True
         path = self._to_path(self.in_dir, name)
-        ior = ReadableProxyFile(url, path, is_binary=binary_content, writable_also=True, use_temp_file=use_temp_file)
-        download(url, ior._file_obj, close_fhdl=False)
+        ior = ReadableProxyFile(url, path, url, is_binary=binary_content, writable_also=True, use_temp_file=use_temp_file)
+        #download(url, ior._file_obj, close_fhdl=False)
         logger.debug("LocalIOAdapter#read_external: Read external content '%s' into '%s'", url, ior.name)
         return ior
 
@@ -249,7 +249,7 @@ class LocalIOAdapter(IOAdapter):
             IOReadable: The content of the local file as a file-like object
         """
         path = self._to_path(self.in_dir, name, collection_name)
-        return ReadableProxyFile(name, path, is_binary=binary_content, use_temp_file=False)
+        return ReadableProxyFile(name, path, None, is_binary=binary_content, use_temp_file=False)
 
     # def readable(self, name: str, collection_name: str = None) -> bool:
     #     file_name = self._to_path(self.in_dir, name, collection_name)

--- a/sdk_service/src/ivcap_sdk_service/cio/readable_proxy_file.py
+++ b/sdk_service/src/ivcap_sdk_service/cio/readable_proxy_file.py
@@ -4,11 +4,11 @@
 # found in the LICENSE file. See the AUTHORS file for names of contributors.
 #
 from builtins import BaseException
-import pathlib
-from typing import IO, AnyStr, Callable, List, Tuple, Union, BinaryIO, Dict
+from typing import IO, AnyStr, Callable, List, Optional
 import tempfile
 import io
-import shutil
+
+from ivcap_sdk_service.cio.utils import download
 from ..logger import sys_logger as logger
 
 from .io_adapter import IOReadable
@@ -17,7 +17,8 @@ class ReadableProxyFile(IOReadable):
 
     def __init__(self, 
         name: str,
-        path: str,
+        path: Optional[str],
+        download_url: Optional[str],
         on_close: Callable[[IO[bytes]], None]=None, 
         is_binary=True, 
         use_temp_file=True, 
@@ -29,14 +30,17 @@ class ReadableProxyFile(IOReadable):
             self._mode = "w+b" if is_binary else "w+"
         else:
             self._mode = "rb" if is_binary else "r"
-        if use_temp_file:
-            self._file_obj = tempfile.NamedTemporaryFile(self._mode, encoding=encoding) # delete after uploaded
-            self._path = self._file_obj.name
-        else:
-            self._path = path
-            self._file_obj = io.open(path, mode=self._mode, encoding=encoding)
+
         self._name = name
+        self._path = path
+        self._is_binary = is_binary
+        self._download_url = download_url
+        self._use_temp_file = use_temp_file
+        self._encoding = encoding
         self._on_close = on_close
+        self._writable_also = writable_also
+        self._offset = 0
+        self._file_obj = None
         self._closed = False
 
     @property
@@ -51,12 +55,12 @@ class ReadableProxyFile(IOReadable):
     def name(self) -> str:
         return self._name
 
-    @property
-    def path(self) -> str:
+    def as_local_file(self) -> str:
+        self._get_file_obj()
         return self._path
 
     def writable(self) -> bool:
-        return False
+        return self._writable_also
 
     def readable(self) -> bool:
         return True
@@ -65,7 +69,13 @@ class ReadableProxyFile(IOReadable):
         """
         Change stream position by offset
         """
-        return self._file_obj.seek(offset, whence)
+        # if whence == io.SEEK_SET:
+        #     self._offset = offset
+        # elif whence == io.SEEK_CUR:
+        #     self._offset += offset
+        # else:
+        #     raise OSError(-1, "cannot seek from end")
+        self._get_file_obj().seek(offset, whence)
 
     def seekable(self) -> bool:
         return True
@@ -74,30 +84,57 @@ class ReadableProxyFile(IOReadable):
         """
         Return current stream position
         """
-        return self._file_obj.tell()
+        return self._get_file_obj().tell()
 
     def read(self, n: int = -1) -> AnyStr:
-        return self._file_obj.read(n)
+        return self._get_file_obj().read(n)
 
     def readline(self, limit: int = -1) -> AnyStr:
-        return self._file_obj.readline(limit)
+        return self._get_file_obj().readline(limit)
 
     def readlines(self, hint: int = -1) -> List[AnyStr]:
-        return self._file_obj.readlines(hint)
+        return self._get_file_obj().readlines(hint)
 
     def close(self):
         self._closed = True
-        
+        f = self._get_file_obj()
         try:
             if self._on_close:
-                self._on_close(self._file_obj)
+                self._on_close(f)
         except BaseException as err:
             logger.warn("ReadableProxyFile#close: on_close '%s' failed with '%s'", self._on_close, err)
         finally:
-            self._file_obj.close()
+            f.close()
+
+    def _get_file_obj(self):
+        if self._file_obj == None:
+            self._open_file_obj()
+        return self._file_obj
+    
+    def _open_file_obj(self):
+        """Open and ensure that the local file object is properly "filled".
+
+        If the content is from an external source, ensure that it is fully
+        downloaded into `_file_obj`.
+        """
+
+        if self._download_url:
+            mode = "w+b" if self._is_binary else "w+"
+            self._file_obj = tempfile.NamedTemporaryFile(mode, encoding=self._encoding)
+            self._path = self._file_obj.name
+            try:
+                download(self._download_url, self._file_obj, close_fhdl=False)
+            except BaseException as ex:
+                logger.error("ReadableProxyFile#_open_file_obj: While downloading - %s", ex.__repr__())
+                raise ex
+            
+            logger.debug("ReadableProxyFile#_open_file_obj: Read external content '%s' into '%s'", self._download_url, self._path)
+
+        elif self._path:
+            self._file_obj = io.open(self._path, mode=self._mode, encoding=self._encoding)
 
     def __repr__(self):
-        return f"<ReadableProxyFile name={self._name} closed={self._closed} mode={self._mode} fp={self._file_obj}>"
+        return f"<ReadableProxyFile name={self._name} closed={self._closed} mode={self._mode}>"
 
     def to_json(self):
         return self._name

--- a/sdk_service/src/ivcap_sdk_service/cio/utils.py
+++ b/sdk_service/src/ivcap_sdk_service/cio/utils.py
@@ -3,14 +3,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file. See the AUTHORS file for names of contributors.
 #
-from hashlib import sha256
-import io
-import json
-import re
-from typing import Any, BinaryIO
-import uuid
+from typing import BinaryIO
 import requests
-from pathlib import Path
 
 from ..logger import sys_logger as logger
 from ..itypes import Url


### PR DESCRIPTION
Previously the ReadableProxy immediately fetched external data in the constructor. This meant that it may have have taken a long time before the actual service was called. It also meant that we may fetch data we never need. But more importantly, going forward we may only want to fetch parts of the external data. We now have support for that in DataProxy, but right now don't use it. We simply delay loading external data into a local temp file the first time someone calls any of the file related methods.